### PR TITLE
Feat. POST api/video/edit: apply text and sticker to the video and return final result

### DIFF
--- a/src/constants/paths.js
+++ b/src/constants/paths.js
@@ -7,3 +7,4 @@ exports.SAVING_DIR_BLEND_FRAMES = path.join(__dirname, "../../blend");
 exports.SAVING_DIR_ORIGINAL_FRAMES = path.join(__dirname, "../../original");
 exports.SAVING_DIR_CROPPED_FRAMES = path.join(__dirname, "../../cropped");
 exports.SAVING_DIR_RESULT = path.join(__dirname, "../../result");
+exports.SAVING_DIR_EDITED_RESULT = path.join(__dirname, "../../edited");

--- a/src/controllers/cleanup.controller.js
+++ b/src/controllers/cleanup.controller.js
@@ -1,0 +1,10 @@
+const { clearDirectories } = require("../service/clearDirectories");
+
+exports.cleanup = async (req, res) => {
+  try {
+    await clearDirectories();
+  } catch (error) {
+    console.error("Error occured:", error);
+    return { success: false, error };
+  }
+};

--- a/src/controllers/crop.controller.js
+++ b/src/controllers/crop.controller.js
@@ -1,7 +1,6 @@
 const { cropFrames } = require("../service/cropFrames");
 const { reassembleFrames } = require("../service/reassembleFrames");
 const { uploadToS3 } = require("../service/uploadToS3");
-const { clearDirectories } = require("../service/clearDirectories");
 const { extractOriginalFrames } = require("../service/extractOriginalFrames");
 
 exports.cropVideo = async (req, res) => {
@@ -12,12 +11,11 @@ exports.cropVideo = async (req, res) => {
       result.targetFolder,
       "cropped",
     );
-    const analysisVideoUrl = await uploadToS3(assembledFile, "cropped");
-    await clearDirectories();
+    const croppedVideoUrl = await uploadToS3(assembledFile, "cropped");
 
     res.send({
       success: true,
-      url: analysisVideoUrl,
+      url: croppedVideoUrl,
     });
   } catch (error) {
     console.error("Something went wrong:", error);

--- a/src/controllers/edit.controller.js
+++ b/src/controllers/edit.controller.js
@@ -1,0 +1,19 @@
+const { uploadToS3 } = require("../service/uploadToS3");
+const { getEditedVideo } = require("../service/getEditedVideo");
+const { downloadIngredients } = require("../service/downloadIngredients");
+
+exports.editVideo = async (req, res) => {
+  try {
+    const downloadedFiles = await downloadIngredients(req.body);
+    const editedFile = await getEditedVideo(req.body, downloadedFiles);
+    const finalVideoUrl = await uploadToS3(editedFile, "edited");
+
+    res.send({
+      success: true,
+      url: finalVideoUrl,
+    });
+  } catch (error) {
+    console.error("Error occured while rendering final edited video:", error);
+    return { success: false, error };
+  }
+};

--- a/src/routes/video.js
+++ b/src/routes/video.js
@@ -3,9 +3,13 @@ const router = express.Router();
 const upload = require("../middleware/multer");
 const analysisController = require("../controllers/analysis.controller");
 const cropController = require("../controllers/crop.controller");
+const editController = require("../controllers/edit.controller");
+const cleanupController = require("../controllers/cleanup.controller");
 
 const { tryCatch } = require("../util/tryCatch");
 const { multerErrorHandler } = require("../util/multerErrorHandler");
+
+router.put("/clean", cleanupController.cleanup);
 
 router.post(
   "/analysis",
@@ -15,5 +19,7 @@ router.post(
 );
 
 router.post("/crop", tryCatch(cropController.cropVideo));
+
+router.post("/edit", tryCatch(editController.editVideo));
 
 module.exports = router;

--- a/src/service/clearDirectories.js
+++ b/src/service/clearDirectories.js
@@ -7,6 +7,7 @@ const {
   SAVING_DIR_ORIGINAL_FRAMES,
   SAVING_DIR_CROPPED_FRAMES,
   SAVING_DIR_RESULT,
+  SAVING_DIR_EDITED_RESULT,
 } = require("../constants/paths");
 
 exports.clearDirectories = async () => {
@@ -18,15 +19,17 @@ exports.clearDirectories = async () => {
     SAVING_DIR_ORIGINAL_FRAMES,
     SAVING_DIR_CROPPED_FRAMES,
     SAVING_DIR_RESULT,
+    SAVING_DIR_EDITED_RESULT,
   ];
 
   try {
-    for (const directory of directoriesToDelete) {
-      await fs.rm(directory, { recursive: true });
-      console.log(`Directory '${directory}' deleted successfully.`);
-    }
+    await Promise.all(
+      directoriesToDelete.map(async (directory) => {
+        await fs.rm(directory, { recursive: true });
+        console.log(`Directory '${directory}' deleted successfully.`);
+      }),
+    );
   } catch (error) {
-    console.error("Error while deleting directory:", error);
-    throw error;
+    console.log("alrady not existing: " + error);
   }
 };

--- a/src/service/downloadIngredients.js
+++ b/src/service/downloadIngredients.js
@@ -1,0 +1,59 @@
+const { S3Client, GetObjectCommand } = require("@aws-sdk/client-s3");
+const config = require("../constants/config");
+const fs = require("fs").promises;
+const path = require("path");
+const { SAVING_DIR_EDITED_RESULT } = require("../constants/paths");
+
+const s3Client = new S3Client({
+  region: config.AWS_S3_REGION,
+  credentials: {
+    accessKeyId: config.AWS_ACCESS_KEY,
+    secretAccessKey: config.AWS_SECRET_ACCESS_KEY,
+  },
+});
+
+exports.downloadIngredients = async (object) => {
+  const { typeface, stickerName } = object;
+  const bucketName = config.AWS_BUCKET_NAME;
+
+  const results = {};
+
+  try {
+    if (typeface) {
+      const downloadParams = {
+        Bucket: bucketName,
+        Key: `fonts/${typeface}.ttf`,
+      };
+
+      const downloadCommand = new GetObjectCommand(downloadParams);
+      const data = await s3Client.send(downloadCommand);
+
+      const localPath = path.join(SAVING_DIR_EDITED_RESULT, `${typeface}.ttf`);
+      await fs.writeFile(localPath, data.Body);
+
+      results.typefacePath = localPath;
+    }
+
+    if (stickerName) {
+      const downloadParams = {
+        Bucket: bucketName,
+        Key: `stickers/${stickerName}.png`,
+      };
+
+      const downloadCommand = new GetObjectCommand(downloadParams);
+      const data = await s3Client.send(downloadCommand);
+
+      const localPath = path.join(
+        SAVING_DIR_EDITED_RESULT,
+        `${stickerName}.png`,
+      );
+      await fs.writeFile(localPath, data.Body);
+
+      results.stickerPath = localPath;
+    }
+
+    return results;
+  } catch (error) {
+    console.error("Error downloading file:", error);
+  }
+};

--- a/src/service/downloadIngredients.js
+++ b/src/service/downloadIngredients.js
@@ -3,6 +3,7 @@ const config = require("../constants/config");
 const fs = require("fs").promises;
 const path = require("path");
 const { SAVING_DIR_EDITED_RESULT } = require("../constants/paths");
+const { ensureFolderExists } = require("../util/ensureFolderExists");
 
 const s3Client = new S3Client({
   region: config.AWS_S3_REGION,
@@ -13,6 +14,7 @@ const s3Client = new S3Client({
 });
 
 exports.downloadIngredients = async (object) => {
+  ensureFolderExists(SAVING_DIR_EDITED_RESULT);
   const { typeface, stickerName } = object;
   const bucketName = config.AWS_BUCKET_NAME;
 
@@ -51,9 +53,9 @@ exports.downloadIngredients = async (object) => {
 
       results.stickerPath = localPath;
     }
-
-    return results;
   } catch (error) {
     console.error("Error downloading file:", error);
   }
+
+  return results;
 };

--- a/src/service/extractAudio.js
+++ b/src/service/extractAudio.js
@@ -26,11 +26,11 @@ exports.extractAudio = async (file) => {
 
   return new Promise(
     (resolve) => {
-      ffmpegAudio.stdout.on("data", (x) => {
-        process.stdout.write(x.toString());
+      ffmpegAudio.stdout.on("data", (data) => {
+        process.stdout.write(data.toString());
       });
-      ffmpegAudio.stderr.on("data", (x) => {
-        process.stderr.write(x.toString());
+      ffmpegAudio.stderr.on("data", (data) => {
+        process.stderr.write(data.toString());
       });
       ffmpegAudio.on("close", resolve);
     },

--- a/src/service/extractDownscaledFrames.js
+++ b/src/service/extractDownscaledFrames.js
@@ -23,11 +23,11 @@ exports.extractDownscaledFrames = async (file) => {
 
   return new Promise(
     (resolve) => {
-      ffmpegDownscale.stdout.on("data", (x) => {
-        process.stdout.write(x.toString());
+      ffmpegDownscale.stdout.on("data", (data) => {
+        process.stdout.write(data.toString());
       });
-      ffmpegDownscale.stderr.on("data", (x) => {
-        process.stderr.write(x.toString());
+      ffmpegDownscale.stderr.on("data", (data) => {
+        process.stderr.write(data.toString());
       });
       ffmpegDownscale.on("close", resolve);
     },

--- a/src/service/extractOriginalFrames.js
+++ b/src/service/extractOriginalFrames.js
@@ -26,11 +26,11 @@ exports.extractOriginalFrames = async () => {
 
   return new Promise(
     (resolve) => {
-      ffmpegOriginal.stdout.on("data", (x) => {
-        process.stdout.write(x.toString());
+      ffmpegOriginal.stdout.on("data", (data) => {
+        process.stdout.write(data.toString());
       });
-      ffmpegOriginal.stderr.on("data", (x) => {
-        process.stderr.write(x.toString());
+      ffmpegOriginal.stderr.on("data", (data) => {
+        process.stderr.write(data.toString());
       });
       ffmpegOriginal.on("close", resolve);
     },

--- a/src/service/getEditedVideo.js
+++ b/src/service/getEditedVideo.js
@@ -24,8 +24,6 @@ exports.getEditedVideo = async (object, downloadedFiles) => {
     stickerY,
   } = object;
 
-  console.log(typeface, stickerName);
-
   const ffmpegArgument = [];
 
   if (typeface && !stickerName) {
@@ -33,7 +31,7 @@ exports.getEditedVideo = async (object, downloadedFiles) => {
       "-i",
       path.join(SAVING_DIR_RESULT, "result_video.mp4"),
       "-vf",
-      `drawtext=text="${fontContent}":x=${fontX}:y=${fontY}:fontsize=16:fontcolor=${fontColor}:fontfile=${downloadedFiles.typefacePath}:box=1:boxcolor=${fontBg}:boxborderw=${fontWidth}`,
+      `drawbox=x=${fontX}:y=${fontY - 4}:w=${fontWidth}:h=35:color=${fontBg}:t=fill,drawtext=text=${fontContent}:x=(406-text_w)/2:y=${fontY}:fontsize=30:fontcolor=${fontColor}:fontfile=${downloadedFiles.typefacePath}`,
     );
   }
 
@@ -51,11 +49,11 @@ exports.getEditedVideo = async (object, downloadedFiles) => {
   if (stickerName && typeface) {
     ffmpegArgument.push(
       "-i",
-      downloadedFiles.stickerPath,
-      "-i",
       path.join(SAVING_DIR_RESULT, "result_video.mp4"),
-      "-vf",
-      `drawtext=text="${fontContent}":x=${fontX}:y=${fontY}:fontsize=16:fontcolor=${fontColor}:fontfile=${downloadedFiles.typefacePath}:box=1:boxcolor=${fontBg},overlay=x=${stickerX}:y=${stickerY}`,
+      "-i",
+      downloadedFiles.stickerPath,
+      "-filter_complex",
+      `[1:v]scale=150:-1[scaled_sticker];[0:v][scaled_sticker]overlay=x=${stickerX}:y=${stickerY},drawbox=x=${fontX}:y=${fontY - 7}:w=${fontWidth}:h=35:color=${fontBg}:t=fill,drawtext=text=${fontContent}:x=${fontX}+${fontWidth}/2-text_w/2:y=${fontY}:fontsize=30:fontcolor=${fontColor}:fontfile=${downloadedFiles.typefacePath}`,
     );
   }
 
@@ -63,8 +61,6 @@ exports.getEditedVideo = async (object, downloadedFiles) => {
     "-y",
     path.join(SAVING_DIR_EDITED_RESULT, "edited_video.mp4"),
   );
-
-  console.log(ffmpegArgument);
 
   const ffmpegEditVideo = execFile(ffmpegPath, ffmpegArgument);
 

--- a/src/service/getEditedVideo.js
+++ b/src/service/getEditedVideo.js
@@ -1,0 +1,88 @@
+const ffmpegPath = require("@ffmpeg-installer/ffmpeg").path;
+const execFile = require("child_process").spawn;
+const path = require("path");
+
+const {
+  SAVING_DIR_RESULT,
+  SAVING_DIR_EDITED_RESULT,
+} = require("../constants/paths");
+const { ensureFolderExists } = require("../util/ensureFolderExists");
+
+exports.getEditedVideo = async (object, downloadedFiles) => {
+  ensureFolderExists(SAVING_DIR_EDITED_RESULT);
+
+  const {
+    typeface,
+    fontContent,
+    fontX,
+    fontY,
+    fontWidth,
+    fontColor,
+    fontBg,
+    stickerName,
+    stickerX,
+    stickerY,
+  } = object;
+
+  console.log(typeface, stickerName);
+
+  const ffmpegArgument = [];
+
+  if (typeface && !stickerName) {
+    ffmpegArgument.push(
+      "-i",
+      path.join(SAVING_DIR_RESULT, "result_video.mp4"),
+      "-vf",
+      `drawtext=text="${fontContent}":x=${fontX}:y=${fontY}:fontsize=16:fontcolor=${fontColor}:fontfile=${downloadedFiles.typefacePath}:box=1:boxcolor=${fontBg}:boxborderw=${fontWidth}`,
+    );
+  }
+
+  if (stickerName && !typeface) {
+    ffmpegArgument.push(
+      "-i",
+      path.join(SAVING_DIR_RESULT, "result_video.mp4"),
+      "-i",
+      downloadedFiles.stickerPath,
+      "-filter_complex",
+      `[1:v]scale=150:-1[scaled_sticker];[0:v][scaled_sticker]overlay=x=${stickerX}:y=${stickerY}`,
+    );
+  }
+
+  if (stickerName && typeface) {
+    ffmpegArgument.push(
+      "-i",
+      downloadedFiles.stickerPath,
+      "-i",
+      path.join(SAVING_DIR_RESULT, "result_video.mp4"),
+      "-vf",
+      `drawtext=text="${fontContent}":x=${fontX}:y=${fontY}:fontsize=16:fontcolor=${fontColor}:fontfile=${downloadedFiles.typefacePath}:box=1:boxcolor=${fontBg},overlay=x=${stickerX}:y=${stickerY}`,
+    );
+  }
+
+  ffmpegArgument.push(
+    "-y",
+    path.join(SAVING_DIR_EDITED_RESULT, "edited_video.mp4"),
+  );
+
+  console.log(ffmpegArgument);
+
+  const ffmpegEditVideo = execFile(ffmpegPath, ffmpegArgument);
+
+  return new Promise(
+    (resolve) => {
+      ffmpegEditVideo.stdout.on("data", (data) => {
+        process.stdout.write(data.toString());
+      });
+      ffmpegEditVideo.stderr.on("data", (data) => {
+        process.stderr.write(data.toString());
+      });
+      ffmpegEditVideo.on("close", () => {
+        resolve(path.join(SAVING_DIR_EDITED_RESULT, "edited_video.mp4"));
+      });
+    },
+    (reject) => {
+      console.error("Error occured editing video:", reject);
+      return false;
+    },
+  );
+};

--- a/src/service/reassembleFrames.js
+++ b/src/service/reassembleFrames.js
@@ -29,11 +29,11 @@ exports.reassembleFrames = async (targetFolder, type) => {
 
   return new Promise(
     (resolve) => {
-      ffmpegReassemble.stdout.on("data", (x) => {
-        process.stdout.write(x.toString());
+      ffmpegReassemble.stdout.on("data", (data) => {
+        process.stdout.write(data.toString());
       });
-      ffmpegReassemble.stderr.on("data", (x) => {
-        process.stderr.write(x.toString());
+      ffmpegReassemble.stderr.on("data", (data) => {
+        process.stderr.write(data.toString());
       });
       ffmpegReassemble.on("close", () => {
         resolve(path.join(SAVING_DIR_RESULT, "result_video.mp4"));


### PR DESCRIPTION
### Task 🖍

- [[BE] 영상 꾸미기 Feature](https://www.notion.so/vanillacoding/FE-BE-Feature-d202274c2bd94ebba3f792c34f91d598?pvs=4)

### Description 🗯

#### 주요 구현사항:
- 일반
1. 메인화면에 진입할 경우 temp파일들을 모두 삭제하여 리셋하는 endpoint를 구현.
2. S3에 이미지 업로드

- edit 관련
1. edit전 요소를 다운로드 받는 downloadIngredients함수를 구현.
=> ffmpeg를 이용해 이미지를 삽입하려면 local path가 필요하기 때문. 3S의 getObjectCommand를 이용하여 로컬경로에 다운로드한 후 ffmpeg함수로 넘어가도록 함.
text와 sticker 둘 중 하나만 있을경우와 둘 다 있을 경우를 분기처리하여 객체에 담도록 함.

2. ffmpeg를 이용하여 꾸미기 요소 합치는 getEditedVideo함수를 구현.
=> 클라이언트에서 넘어온 설정 데이터와, 앞서 downloadIngredients가 준비해준 파일경로들을 인자로 받아 실행.
text와 sticker 둘 중 하나만 있을경우와 둘 다 있을 경우를 분기처리하여 ffmpeg에 적절한 arguments를 전달한다.