### PR TITLE
Feat. move optimization logic from client to server

### DIFF
--- a/src/constants/constant.js
+++ b/src/constants/constant.js
@@ -1,3 +1,4 @@
 exports.BLEND_FRAME_WIDTH = 100;
 exports.BLEND_FRAME_HEIGHT = 56;
 exports.MOTION_THRESHOLD = 250;
+exports.RESULT_WIDTH = 320;

--- a/src/constants/error.js
+++ b/src/constants/error.js
@@ -5,4 +5,3 @@ exports.ALREADY_VERTICAL = "The video is already in verical format";
 exports.RATIO_NOT_SUPPORTED = "ratio of the given video is not supported";
 exports.TOO_LONG_OR_SHORT = "length of video must be between 5 to 60 sec";
 exports.NO_FRAME_EXISTS = "No frames inside folder to process";
-exports.NO_IMAGE_EXISTS = "No frames inside folder to analyze";

--- a/src/constants/error.js
+++ b/src/constants/error.js
@@ -1,5 +1,5 @@
 exports.UPLOAD_FAILED = "Error occured while uploading video";
-exports.ONLY_MP4_MOV_ALLOWED = "Only mp4 and mov are allowed";
+exports.EXTENTION_NOT_SUPPORTED = "Only .mp4, .mov, .wmv, .avi are allowed";
 exports.VIDEO_TOO_LARGE = "Video size exceeds the limit of 100MB";
 exports.ALREADY_VERTICAL = "The video is already in verical format";
 exports.RATIO_NOT_SUPPORTED = "ratio of the given video is not supported";

--- a/src/constants/paths.js
+++ b/src/constants/paths.js
@@ -8,4 +8,5 @@ exports.SAVING_DIR_BLEND_FRAMES = path.join(__dirname, "../../temp/blend");
 exports.SAVING_DIR_ORIGINAL_FRAMES = path.join(__dirname, "../../temp/original");
 exports.SAVING_DIR_CROPPED_FRAMES = path.join(__dirname, "../../temp/cropped");
 exports.SAVING_DIR_RESULT = path.join(__dirname, "../../temp/result");
+exports.SAVING_DIR_INGREDIENTS = path.join(__dirname, "../../temp/ingredients");
 exports.SAVING_DIR_EDITED_RESULT = path.join(__dirname, "../../temp/edited");

--- a/src/controllers/analysis.controller.js
+++ b/src/controllers/analysis.controller.js
@@ -27,8 +27,8 @@ exports.analyzeVideo = async (req, res) => {
     const videoWidth = await getMetaData(req.file);
     await extractDownscaledFrames(req.file);
     await extractAudio(req.file);
-    await createBlendFrames();
-    const result = await analyzePixelData();
+    const downscaleFilesNum = await createBlendFrames();
+    const result = await analyzePixelData(downscaleFilesNum);
     const assembledFile = await reassembleFrames(result.targetFolder);
     const analysisVideoUrl = await uploadToS3(assembledFile, "analysis");
 

--- a/src/controllers/crop.controller.js
+++ b/src/controllers/crop.controller.js
@@ -2,25 +2,60 @@ const CreateError = require("http-errors");
 const fs = require("fs").promises;
 
 const {
+  SAVING_DIR_VIDEO,
+  SAVING_DIR_BLEND_FRAMES,
   SAVING_DIR_ORIGINAL_FRAMES,
   SAVING_DIR_CROPPED_FRAMES,
 } = require("../constants/paths");
 
+const { analyzePixelData } = require("../service/analyzePixelData");
+const { optimizeArray } = require("../service/optimizeArray");
 const { cropFrames } = require("../service/cropFrames");
 const { reassembleFrames } = require("../service/reassembleFrames");
 const { uploadToS3 } = require("../service/uploadToS3");
 const { extractOriginalFrames } = require("../service/extractOriginalFrames");
+const { createFixedArray } = require("../service/createFixedArray");
+const { getMetaData } = require("../service/getMetaData");
 
 exports.cropVideo = async (req, res) => {
+  const { defaultX, defaultW, isFixed, sensitivity } = req.body;
+  const leftEdge = Math.round(defaultX / 10);
+  const rightEdge = Math.round((defaultX + defaultW) / 10);
+
   try {
+    const videoWidth = await getMetaData();
     await extractOriginalFrames();
-    const result = await cropFrames(req.body);
-    const assembledFile = await reassembleFrames(
-      result.targetFolder,
-      "cropped",
-    );
+    const files = await fs.readdir(SAVING_DIR_BLEND_FRAMES);
+    const filesNum = files.length;
+
+    if (isFixed) {
+      const fixedCoordArray = await createFixedArray(
+        leftEdge,
+        filesNum,
+        videoWidth,
+      );
+      await cropFrames(fixedCoordArray);
+    }
+
+    if (!isFixed) {
+      const motionAnalysisArray = await analyzePixelData(
+        leftEdge,
+        rightEdge,
+        filesNum,
+      );
+      const optimizedArray = await optimizeArray(
+        motionAnalysisArray,
+        sensitivity,
+        videoWidth,
+      );
+      await cropFrames(optimizedArray);
+    }
+
+    const assembledFile = await reassembleFrames("cropped");
     const croppedVideoUrl = await uploadToS3(assembledFile, "cropped");
 
+    await fs.rm(SAVING_DIR_VIDEO, { recursive: true });
+    await fs.rm(SAVING_DIR_BLEND_FRAMES, { recursive: true });
     await fs.rm(SAVING_DIR_ORIGINAL_FRAMES, { recursive: true });
     await fs.rm(SAVING_DIR_CROPPED_FRAMES, { recursive: true });
 

--- a/src/controllers/edit.controller.js
+++ b/src/controllers/edit.controller.js
@@ -2,7 +2,6 @@ const CreateError = require("http-errors");
 const fs = require("fs").promises;
 
 const {
-  SAVING_DIR_VIDEO,
   SAVING_DIR_AUDIO,
   SAVING_DIR_RESULT,
   SAVING_DIR_INGREDIENTS,
@@ -19,7 +18,6 @@ exports.editVideo = async (req, res) => {
     const editedFile = await getEditedVideo(req.body, downloadedFiles);
     const finalVideoUrl = await uploadToS3(editedFile, "edited");
 
-    await fs.rm(SAVING_DIR_VIDEO, { recursive: true });
     await fs.rm(SAVING_DIR_AUDIO, { recursive: true });
     await fs.rm(SAVING_DIR_RESULT, { recursive: true });
     await fs.rm(SAVING_DIR_INGREDIENTS, { recursive: true });

--- a/src/controllers/edit.controller.js
+++ b/src/controllers/edit.controller.js
@@ -5,6 +5,7 @@ const {
   SAVING_DIR_VIDEO,
   SAVING_DIR_AUDIO,
   SAVING_DIR_RESULT,
+  SAVING_DIR_INGREDIENTS,
   SAVING_DIR_EDITED_RESULT,
 } = require("../constants/paths");
 
@@ -21,6 +22,7 @@ exports.editVideo = async (req, res) => {
     await fs.rm(SAVING_DIR_VIDEO, { recursive: true });
     await fs.rm(SAVING_DIR_AUDIO, { recursive: true });
     await fs.rm(SAVING_DIR_RESULT, { recursive: true });
+    await fs.rm(SAVING_DIR_INGREDIENTS, { recursive: true });
     await fs.rm(SAVING_DIR_EDITED_RESULT, { recursive: true });
 
     res.send({

--- a/src/controllers/preview.controller.js
+++ b/src/controllers/preview.controller.js
@@ -4,7 +4,6 @@ const fs = require("fs").promises;
 const { UPLOAD_FAILED } = require("../constants/error");
 const {
   SAVING_DIR_VIDEO,
-  SAVING_DIR_BLEND_FRAMES,
   SAVING_DIR_DOWNSCALED_FRAMES,
 } = require("../constants/paths");
 
@@ -13,33 +12,28 @@ const {
 } = require("../service/extractDownscaledFrames");
 const { extractAudio } = require("../service/extractAudio");
 const { createBlendFrames } = require("../service/createBlendFrames");
-const { analyzePixelData } = require("../service/analyzePixelData");
 const { reassembleFrames } = require("../service/reassembleFrames");
 const { uploadToS3 } = require("../service/uploadToS3");
 const { getMetaData } = require("../service/getMetaData");
 
-exports.analyzeVideo = async (req, res) => {
+exports.createPreviewVideo = async (req, res) => {
   if (!req.file) {
     throw CreateError(400, UPLOAD_FAILED);
   }
 
   try {
-    const videoWidth = await getMetaData(req.file);
+    await getMetaData();
     await extractDownscaledFrames(req.file);
     await extractAudio(req.file);
-    const downscaleFilesNum = await createBlendFrames();
-    const result = await analyzePixelData(downscaleFilesNum);
-    const assembledFile = await reassembleFrames(result.targetFolder);
-    const analysisVideoUrl = await uploadToS3(assembledFile, "analysis");
+    await createBlendFrames();
+    const assembledFile = await reassembleFrames("blend");
+    const analysisVideoUrl = await uploadToS3(assembledFile, "preview");
 
-    await fs.rm(SAVING_DIR_BLEND_FRAMES, { recursive: true });
     await fs.rm(SAVING_DIR_DOWNSCALED_FRAMES, { recursive: true });
 
     res.send({
       success: true,
       url: analysisVideoUrl,
-      startPixelArray: result.startPixelArray,
-      videoWidth,
     });
   } catch (error) {
     await fs.rm(SAVING_DIR_VIDEO, { recursive: true });

--- a/src/middleware/multer.js
+++ b/src/middleware/multer.js
@@ -24,7 +24,7 @@ const upload = multer({
   fileFilter: function (req, file, cb) {
     const ext = path.extname(file.originalname);
 
-    if (ext !== ".mp4" && ext !== ".mov") {
+    if (ext !== ".mp4" && ext !== ".mov" && ext !== ".wmv" && ext !== ".avi") {
       return cb(new CreateError(415, ONLY_MP4_MOV_ALLOWED));
     }
 

--- a/src/routes/video.js
+++ b/src/routes/video.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const router = express.Router();
 const upload = require("../middleware/multer");
-const analysisController = require("../controllers/analysis.controller");
+const previewController = require("../controllers/preview.controller");
 const cropController = require("../controllers/crop.controller");
 const editController = require("../controllers/edit.controller");
 
@@ -9,10 +9,10 @@ const { tryCatch } = require("../util/tryCatch");
 const { multerErrorHandler } = require("../util/multerErrorHandler");
 
 router.post(
-  "/analysis",
+  "/preview",
   upload.single("video"),
   multerErrorHandler,
-  tryCatch(analysisController.analyzeVideo),
+  tryCatch(previewController.createPreviewVideo),
 );
 
 router.post("/crop", tryCatch(cropController.cropVideo));

--- a/src/service/analyzePixelData.js
+++ b/src/service/analyzePixelData.js
@@ -1,9 +1,8 @@
 const CreateError = require("http-errors");
 const sharp = require("sharp");
-const fs = require("fs").promises;
 const path = require("path");
 
-const { NO_IMAGE_EXISTS } = require("../constants/error");
+const { NO_FRAME_EXISTS } = require("../constants/error");
 const {
   BLEND_FRAME_WIDTH,
   BLEND_FRAME_HEIGHT,
@@ -39,18 +38,16 @@ function calculateImageScore(imageData) {
   return centerOfMovedArea;
 }
 
-exports.analyzePixelData = async () => {
+exports.analyzePixelData = async (downscaleFilesNum) => {
   const startPixelArray = [];
+  const blendFilesNum = downscaleFilesNum - 1;
+
+  if (!downscaleFilesNum) {
+    throw CreateError(400, NO_FRAME_EXISTS);
+  }
 
   try {
-    const files = await fs.readdir(SAVING_DIR_BLEND_FRAMES);
-    const filesNum = files.length;
-
-    if (!filesNum) {
-      throw CreateError(400, NO_IMAGE_EXISTS);
-    }
-
-    for (let i = 1; i < filesNum; i++) {
+    for (let i = 1; i < blendFilesNum + 1; i++) {
       const currentImage = path.join(SAVING_DIR_BLEND_FRAMES, `${i}.png`);
 
       await sharp(currentImage)

--- a/src/service/createBlendFrames.js
+++ b/src/service/createBlendFrames.js
@@ -14,14 +14,16 @@ exports.createBlendFrames = async () => {
   ensureFolderExists(SAVING_DIR_BLEND_FRAMES);
 
   try {
-    const files = await fs.readdir(SAVING_DIR_DOWNSCALED_FRAMES);
-    const filesNum = files.length;
+    const files = await fs.readdir(SAVING_DIR_DOWNSCALED_FRAMES, {
+      withFileTypes: true,
+    });
+    const downscaleFilesNum = files.length;
 
-    if (!filesNum) {
+    if (!downscaleFilesNum) {
       throw CreateError(400, NO_FRAME_EXISTS);
     }
 
-    for (let i = 1; i < filesNum; i++) {
+    for (let i = 1; i < downscaleFilesNum; i++) {
       const currentImage = path.join(SAVING_DIR_DOWNSCALED_FRAMES, `${i}.png`);
       const nextImage = path.join(SAVING_DIR_DOWNSCALED_FRAMES, `${i + 1}.png`);
 
@@ -31,6 +33,8 @@ exports.createBlendFrames = async () => {
           if (error) throw error;
         });
     }
+
+    return downscaleFilesNum;
   } catch (error) {
     console.error("Error while creating blend frames:", error);
     throw error;

--- a/src/service/createBlendFrames.js
+++ b/src/service/createBlendFrames.js
@@ -29,12 +29,10 @@ exports.createBlendFrames = async () => {
 
       await sharp(currentImage)
         .composite([{ input: nextImage, blend: "difference" }])
-        .toFile(path.join(SAVING_DIR_BLEND_FRAMES, `${i}.png`), (error) => {
-          if (error) throw error;
-        });
+        .toFile(path.join(SAVING_DIR_BLEND_FRAMES, `${i}.png`));
     }
 
-    return downscaleFilesNum;
+    return { targetFolder: SAVING_DIR_BLEND_FRAMES };
   } catch (error) {
     console.error("Error while creating blend frames:", error);
     throw error;

--- a/src/service/createFixedArray.js
+++ b/src/service/createFixedArray.js
@@ -1,0 +1,20 @@
+const CreateError = require("http-errors");
+const { NO_FRAME_EXISTS } = require("../constants/error");
+
+exports.createFixedArray = async (leftEdge, filesNum, videoWidth) => {
+  const fixedCoordArray = [];
+
+  if (!filesNum) {
+    throw CreateError(400, NO_FRAME_EXISTS);
+  }
+
+  for (let i = 0; i < filesNum * 2 + 1; i++) {
+    if (i % 26 === 0) {
+      continue;
+    }
+
+    fixedCoordArray.push(Math.round((leftEdge / 1000) * videoWidth) * 10);
+  }
+
+  return fixedCoordArray;
+};

--- a/src/service/cropFrames.js
+++ b/src/service/cropFrames.js
@@ -10,13 +10,11 @@ const {
   SAVING_DIR_CROPPED_FRAMES,
 } = require("../constants/paths");
 
-exports.cropFrames = async (startPixelArray) => {
+exports.cropFrames = async (coordinateArray) => {
   ensureFolderExists(SAVING_DIR_CROPPED_FRAMES);
 
   try {
-    const files = await fs.readdir(SAVING_DIR_ORIGINAL_FRAMES, {
-      withFileTypes: true,
-    });
+    const files = await fs.readdir(SAVING_DIR_ORIGINAL_FRAMES);
     const filesNum = files.length;
 
     if (!filesNum) {
@@ -30,7 +28,7 @@ exports.cropFrames = async (startPixelArray) => {
         .extract({
           width: 406,
           height: 720,
-          left: startPixelArray[i - 1],
+          left: coordinateArray[i - 1],
           top: 0,
         })
         .toFile(path.join(SAVING_DIR_CROPPED_FRAMES, `${i}.png`));

--- a/src/service/cropFrames.js
+++ b/src/service/cropFrames.js
@@ -14,14 +14,16 @@ exports.cropFrames = async (startPixelArray) => {
   ensureFolderExists(SAVING_DIR_CROPPED_FRAMES);
 
   try {
-    const files = await fs.readdir(SAVING_DIR_ORIGINAL_FRAMES);
+    const files = await fs.readdir(SAVING_DIR_ORIGINAL_FRAMES, {
+      withFileTypes: true,
+    });
     const filesNum = files.length;
 
     if (!filesNum) {
       throw CreateError(400, NO_FRAME_EXISTS);
     }
 
-    for (let i = 1; i < filesNum; i++) {
+    for (let i = 1; i < filesNum + 1; i++) {
       const currentImage = path.join(SAVING_DIR_ORIGINAL_FRAMES, `${i}.png`);
 
       await sharp(currentImage)

--- a/src/service/downloadIngredients.js
+++ b/src/service/downloadIngredients.js
@@ -2,7 +2,7 @@ const { S3Client, GetObjectCommand } = require("@aws-sdk/client-s3");
 const config = require("../constants/config");
 const fs = require("fs").promises;
 const path = require("path");
-const { SAVING_DIR_EDITED_RESULT } = require("../constants/paths");
+const { SAVING_DIR_INGREDIENTS } = require("../constants/paths");
 const { ensureFolderExists } = require("../util/ensureFolderExists");
 
 const s3Client = new S3Client({
@@ -14,7 +14,7 @@ const s3Client = new S3Client({
 });
 
 exports.downloadIngredients = async (object) => {
-  ensureFolderExists(SAVING_DIR_EDITED_RESULT);
+  ensureFolderExists(SAVING_DIR_INGREDIENTS);
   const { typeface, stickerName } = object;
   const bucketName = config.AWS_BUCKET_NAME;
 
@@ -30,7 +30,7 @@ exports.downloadIngredients = async (object) => {
       const downloadCommand = new GetObjectCommand(downloadParams);
       const data = await s3Client.send(downloadCommand);
 
-      const localPath = path.join(SAVING_DIR_EDITED_RESULT, `${typeface}.ttf`);
+      const localPath = path.join(SAVING_DIR_INGREDIENTS, `${typeface}.ttf`);
       await fs.writeFile(localPath, data.Body);
 
       results.typefacePath = localPath;
@@ -45,10 +45,7 @@ exports.downloadIngredients = async (object) => {
       const downloadCommand = new GetObjectCommand(downloadParams);
       const data = await s3Client.send(downloadCommand);
 
-      const localPath = path.join(
-        SAVING_DIR_EDITED_RESULT,
-        `${stickerName}.png`,
-      );
+      const localPath = path.join(SAVING_DIR_INGREDIENTS, `${stickerName}.png`);
       await fs.writeFile(localPath, data.Body);
 
       results.stickerPath = localPath;

--- a/src/service/getEditedVideo.js
+++ b/src/service/getEditedVideo.js
@@ -27,7 +27,16 @@ exports.getEditedVideo = async (object, downloadedFiles) => {
 
   const ffmpegArgument = [];
 
-  if (typeface && !stickerName) {
+  if (typeface && !stickerName && fontBg === "transparent") {
+    ffmpegArgument.push(
+      "-i",
+      path.join(SAVING_DIR_RESULT, "result_video.mp4"),
+      "-vf",
+      `drawtext=text=${fontContent}:x=(406-text_w)/2:y=${fontY}:fontsize=30:fontcolor=${fontColor}:fontfile=${downloadedFiles.typefacePath}`,
+    );
+  }
+
+  if (typeface && !stickerName && fontBg !== "transparent") {
     ffmpegArgument.push(
       "-i",
       path.join(SAVING_DIR_RESULT, "result_video.mp4"),
@@ -47,7 +56,18 @@ exports.getEditedVideo = async (object, downloadedFiles) => {
     );
   }
 
-  if (stickerName && typeface) {
+  if (stickerName && typeface && fontBg === "transparent") {
+    ffmpegArgument.push(
+      "-i",
+      path.join(SAVING_DIR_RESULT, "result_video.mp4"),
+      "-i",
+      downloadedFiles.stickerPath,
+      "-filter_complex",
+      `[1:v]scale=150:-1[scaled_sticker];[0:v][scaled_sticker]overlay=x=${stickerX}:y=${stickerY},drawtext=text=${fontContent}:x=${fontX}+${fontWidth}/2-text_w/2:y=${fontY}:fontsize=30:fontcolor=${fontColor}:fontfile=${downloadedFiles.typefacePath}`,
+    );
+  }
+
+  if (stickerName && typeface && fontBg !== "transparent") {
     ffmpegArgument.push(
       "-i",
       path.join(SAVING_DIR_RESULT, "result_video.mp4"),

--- a/src/service/getMetaData.js
+++ b/src/service/getMetaData.js
@@ -1,15 +1,21 @@
 const CreateError = require("http-errors");
+const fs = require("fs");
+const path = require("path");
 
 const {
   ALREADY_VERTICAL,
   RATIO_NOT_SUPPORTED,
   TOO_LONG_OR_SHORT,
 } = require("../constants/error");
+const { SAVING_DIR_VIDEO } = require("../constants/paths");
 
 const ffprobePath = require("@ffprobe-installer/ffprobe").path;
 const execFile = require("child_process").spawn;
 
-exports.getMetaData = async (file) => {
+exports.getMetaData = async () => {
+  const files = fs.readdirSync(SAVING_DIR_VIDEO);
+  const firstFile = files[0];
+
   const ffprobeGetMetaData = execFile(ffprobePath, [
     "-v",
     "error",
@@ -21,7 +27,7 @@ exports.getMetaData = async (file) => {
     "format=duration",
     "-of",
     "json",
-    file.path,
+    path.join(SAVING_DIR_VIDEO, firstFile),
   ]);
 
   let outputData = "";

--- a/src/service/optimizeArray.js
+++ b/src/service/optimizeArray.js
@@ -1,0 +1,152 @@
+function replaceZero(motionAnalysisArray) {
+  const result = [];
+
+  for (let i = 0; i < motionAnalysisArray.length; i++) {
+    if (motionAnalysisArray[i] !== 0) {
+      result.push(motionAnalysisArray[i]);
+    } else {
+      const prevNonZeroIndex = i - 1;
+      let currZeroIndex = i;
+      let nextNonZeroIndex = i + 1;
+      let count = 0;
+      let gap = 2;
+
+      if (!i) {
+        while (!motionAnalysisArray[currZeroIndex]) {
+          currZeroIndex++;
+        }
+
+        result.push(motionAnalysisArray[currZeroIndex]);
+        continue;
+      }
+
+      while (
+        nextNonZeroIndex < motionAnalysisArray.length &&
+        motionAnalysisArray[nextNonZeroIndex] === 0
+      ) {
+        nextNonZeroIndex++;
+        gap++;
+      }
+
+      const increment = Math.round(
+        (motionAnalysisArray[nextNonZeroIndex] -
+          motionAnalysisArray[prevNonZeroIndex]) /
+          gap,
+      );
+
+      for (let j = i + 1; j < i + gap; j++) {
+        count++;
+        result.push(motionAnalysisArray[prevNonZeroIndex] + increment * count);
+      }
+
+      i += count - 1;
+    }
+  }
+
+  return result;
+}
+
+function flattenArray(arrayWithoutZero) {
+  const result = arrayWithoutZero;
+
+  for (let i = 1; i < result.length; i++) {
+    const prev = result[i - 1];
+    const curr = result[i];
+    const next = result[i + 1];
+
+    if (
+      Math.abs(prev - curr) >= 4 &&
+      Math.abs(next - curr) >= 4 &&
+      Math.abs(prev - next) <= 5
+    ) {
+      result[i] = Math.round((prev + next) / 2);
+    }
+  }
+
+  return result;
+}
+
+function scaleUpArray(flattenedArray, videoWidth) {
+  const result = [];
+
+  for (let i = 0; i < flattenedArray.length; i++) {
+    const prevValue = (videoWidth / 100) * flattenedArray[i];
+
+    result.push(Math.round(prevValue));
+
+    if (flattenedArray[i + 1]) {
+      const nextValue = (videoWidth / 100) * flattenedArray[i + 1];
+      const middleValue = (nextValue + prevValue) / 2;
+
+      result.push(Math.round(middleValue));
+    }
+  }
+
+  return result;
+}
+
+function applySensitivity(scaledUpArray, sensitivity) {
+  const result = [];
+  const bifurcation = Number(sensitivity);
+
+  for (let i = 0; i < scaledUpArray.length; i += bifurcation) {
+    const currValue = scaledUpArray[i];
+    let count = 0;
+    let gap = bifurcation;
+
+    if (scaledUpArray[i + gap]) {
+      const nextValue = scaledUpArray[i + gap];
+
+      const increment = Math.round((nextValue - currValue) / gap);
+      result.push(currValue);
+
+      for (let j = i + 1; j < i + gap; j++) {
+        count++;
+        result.push(currValue + increment * count);
+      }
+    } else {
+      gap = scaledUpArray.length - 1 - i;
+      const lastValue = scaledUpArray[i + gap];
+
+      const increment = Math.round((lastValue - currValue) / gap);
+      result.push(currValue);
+
+      for (let j = i + 1; j < i + gap; j++) {
+        count++;
+        result.push(currValue + increment * count);
+      }
+
+      result.push(lastValue);
+    }
+  }
+
+  return result;
+}
+
+function adjustLengthOfArray(optimizedArray) {
+  const result = [];
+
+  for (let i = 0; i < optimizedArray.length; i++) {
+    if (i === 0 || i % 26 !== 0) {
+      result.push(optimizedArray[i]);
+    }
+  }
+
+  result.push(optimizedArray[optimizedArray.length - 1]);
+
+  return result;
+}
+
+exports.optimizeArray = async (
+  motionAnalysisArray,
+  sensitivity,
+  videoWidth,
+) => {
+  const arrayWithoutZero = replaceZero(motionAnalysisArray);
+  const flattenedArray = flattenArray(arrayWithoutZero);
+  const scaledUpArray = scaleUpArray(flattenedArray, videoWidth);
+  const optimizedArray = applySensitivity(scaledUpArray, sensitivity);
+  const finalResult = adjustLengthOfArray(optimizedArray);
+
+  return finalResult;
+};

--- a/src/service/reassembleFrames.js
+++ b/src/service/reassembleFrames.js
@@ -3,26 +3,47 @@ const execFile = require("child_process").spawn;
 const path = require("path");
 
 const { ensureFolderExists } = require("../util/ensureFolderExists");
-const { SAVING_DIR_RESULT, SAVING_DIR_AUDIO } = require("../constants/paths");
+const {
+  SAVING_DIR_BLEND_FRAMES,
+  SAVING_DIR_CROPPED_FRAMES,
+  SAVING_DIR_RESULT,
+  SAVING_DIR_AUDIO,
+} = require("../constants/paths");
 
-exports.reassembleFrames = async (targetFolder, type) => {
+exports.reassembleFrames = async (type) => {
   ensureFolderExists(SAVING_DIR_RESULT);
+  let ffmpegArgument;
 
-  const ffmpegArgument = [
-    "-i",
-    path.join(targetFolder, "%01d.png"),
-    "-c:v",
-    "libx264",
-    "-r",
-    "25",
-    "-pix_fmt",
-    "yuv420p",
-    "-y",
-    path.join(SAVING_DIR_RESULT, "result_video.mp4"),
-  ];
+  if (type === "blend") {
+    ffmpegArgument = [
+      "-i",
+      path.join(SAVING_DIR_BLEND_FRAMES, "%01d.png"),
+      "-c:v",
+      "libx264",
+      "-r",
+      "25",
+      "-pix_fmt",
+      "yuv420p",
+      "-y",
+      path.join(SAVING_DIR_RESULT, "result_video.mp4"),
+    ];
+  }
 
   if (type === "cropped") {
-    ffmpegArgument.push("-i", path.join(SAVING_DIR_AUDIO, "audio.mp3"));
+    ffmpegArgument = [
+      "-i",
+      path.join(SAVING_DIR_CROPPED_FRAMES, "%01d.png"),
+      "-i",
+      path.join(SAVING_DIR_AUDIO, "audio.mp3"),
+      "-c:v",
+      "libx264",
+      "-r",
+      "25",
+      "-pix_fmt",
+      "yuv420p",
+      "-y",
+      path.join(SAVING_DIR_RESULT, "result_video.mp4"),
+    ];
   }
 
   const ffmpegReassemble = execFile(ffmpegPath, ffmpegArgument);

--- a/src/util/ensureFolderExists.js
+++ b/src/util/ensureFolderExists.js
@@ -5,7 +5,6 @@ exports.ensureFolderExists = (path) => {
     fs.readdirSync(path).forEach((file) => {
       const filePath = path + "/" + file;
       fs.unlinkSync(filePath);
-      console.log(`File '${filePath}' deleted.`);
     });
   } catch (error) {
     console.error(`${path} doesn't exist. Creating...`);

--- a/src/util/multerErrorHandler.js
+++ b/src/util/multerErrorHandler.js
@@ -1,9 +1,12 @@
 const CreateError = require("http-errors");
-const { ONLY_MP4_MOV_ALLOWED, VIDEO_TOO_LARGE } = require("../constants/error");
+const {
+  EXTENTION_NOT_SUPPORTED,
+  VIDEO_TOO_LARGE,
+} = require("../constants/error");
 
 exports.multerErrorHandler = (error, req, res, next) => {
-  if (error.message === "Only mp4 and mov are allowed") {
-    throw CreateError(415, ONLY_MP4_MOV_ALLOWED);
+  if (error.message === "Only .mp4, .mov, .wmv, .avi are allowed") {
+    throw CreateError(415, EXTENTION_NOT_SUPPORTED);
   }
 
   if (error.message === "File too large") {


### PR DESCRIPTION
### Task 🖍

- [프로젝트 브러시업](https://www.notion.so/vanillacoding/e44ec9dbc66e44bf9b4973d25b091c76?v=a5ba7c91cbd343b4bc426bcb8220831b&p=9f70f6239f434d74bd0cffb972084f07&pm=s)

### Description 🗯
- edit 엔드포인트에서 글귀의 배경으로 "transparent"가 전달되어 올 경우, ffmpeg가 "transparent"를 이해하지 못하는 문제를 발견.
"transparent"가 올 경우 drawbox를 하지 않도록 분기처리함.

- fs.readdir관련, 파일개수 세기를 몇개 남기고 멈추는 현상 등 디버깅.

- 지원하는 영상의 확장자를 mp4, mov, wmv, avi로 조금 더 넓혔다. (테스트 완료)

- 기존 로직은 클라이언트에서 유저가 영역 컨펌을 하면, 영역 좌표를 토대로 바깥에 있는 좌표들을 안쪽으로 밀어주는 방식이었다.
그러나 더 정확한 결과를 위해서는 애초에 유저가 컨펌한 영역 내부에서만 모션분석이 이루어져야하지 않을까 고민하였다.
띠라서 endpoint명을 /analysis에서 /preview로 수정하고, 클라이언트에서 백엔드로 로직을 이동시키는 대규모 리팩토링을 하였음.

- 추가적으로 더욱 나은 결과물을 위해서 다음의 최적화 로직을 추가하였음.

1. 갑작스럽게 튀는 좌표를 눌러주는 로직. (flattenArray 함수)
      예를들어 10, 5, 9와 같은 요소가 나열되어있다면 가운데의 5를 Math.round((10 + 9) / 2)값으로 대체.
      10, 10, 9로 수정하여 튀는 좌표를 모아주게 됌.
      
 2. 매초 남는 1개의 좌표가 시간이 지날수록 점점 쌓여서 밀리는 현상 해결. (adjustLengthOfArray 함수)
리디렉션은 아웃풋으로 25프레임 영상을 반환하며 분석단계에서는 그보다 적은 절반정도만 추출하기로 초기에 디자인하였다. 그러나 12.5 fps는 불가능하기에 12나 13을 선택해야만했다. 0.5 프레임은 존재하지 않기 때문. 좌표 배열을 원본에 맞추어 스케일업 시켜줄 시, 2배를 적용시키면 (13=>26) 매초마다 1개씩 좌표가 남고, 그것이 시간이 지날수록 쌓여서 crop 타이밍이 점점 밀리는 현상이 있었다.
따라서 13개 프레임 추출 방식은 유지하되, adjustLengthOfArray 함수를 최적화 로직 이후에 적용해서, 26의 공배수마다 요소를 제거해주도록 했다. 이로써 배열과 영상이 처음부터 끝까지 영상길이와 관계없이 딱 맞게 되었다.

- 분기점 설정을 유저가 컨펌하도록 방식을 변경.
클라이언트에는 예민, 중간, 덜예민을 정할 수 있는 슬라이더를 구현.
이 input을 통해서 전달되는 숫자를 applySensitivity 함수의 인자로 활용해서, 기존의 상수값으로 고정했었던 방식을 개선하였다.